### PR TITLE
Add parentheses via CSS instead of PHP

### DIFF
--- a/class.bbpress_like.php
+++ b/class.bbpress_like.php
@@ -494,7 +494,7 @@ class bbpress_like {
             $like_number = $this->get_likes_number($post_id);
             if((Bool)$this->settings['settingsbbpl_bbpl_general_show_number'] && $like_number){
                 ?>
-                <span class="bbpl_number">(<?php echo $like_number; ?>)</span>
+                <span class="bbpl_number"><?php echo $like_number; ?></span>
                 <?php
             }
             ?>

--- a/css/bbpl_style.css
+++ b/css/bbpl_style.css
@@ -31,6 +31,14 @@ span.bbpl_number {
     padding: 4px 0;
 }
 
+span.bbpl_number:before {
+    content: '(';
+}
+
+span.bbpl_number:after {
+    content: ')';
+}
+
 .bbpl_button.liked span {
     margin-right: 5px;
 }


### PR DESCRIPTION
This allows overriding the 'like' number CSS.